### PR TITLE
Improve tool call rendering with boxed styling

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -447,19 +447,18 @@ function renderToolBlock(
               ? "success"
               : "warning";
 
-    const innerLines = [title, ...bodyLines];
-    const wrappedLines = innerLines.map((line) => {
-        const content = line === "" ? " " : line;
-        return `${theme.fg(borderColor, "│")} ${theme.bg(bg, content)} ${theme.fg(borderColor, "│")}`;
-    });
+    const separator = theme.fg(borderColor, "─".repeat(120));
+    const blockLines: string[] = ["", separator, `  ${title}`];
 
-    return [
-        "",
-        theme.fg(borderColor, "╭─ tool call ─"),
-        ...wrappedLines,
-        theme.fg(borderColor, "╰─────────────"),
-        "",
-    ].join("\n");
+    if (bodyLines.length > 0) {
+        blockLines.push("");
+        for (const line of bodyLines) {
+            blockLines.push(`  ${line}`);
+        }
+    }
+
+    blockLines.push(separator, "");
+    return blockLines.join("\n");
 }
 
 export function renderCompletedToolCall(

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -187,8 +187,8 @@ function formatToolCallTitle(
                 command == null
                     ? invalidArgLabel()
                     : command
-                        ? command
-                        : theme.fg("toolOutput", "...");
+                      ? command
+                      : theme.fg("toolOutput", "...");
             return theme.fg("toolTitle", theme.bold(`$ ${commandDisplay}`));
         }
         case "read": {
@@ -197,8 +197,8 @@ function formatToolCallTitle(
                 path == null
                     ? invalidArgLabel()
                     : path
-                        ? theme.fg("accent", path)
-                        : theme.fg("toolOutput", "...");
+                      ? theme.fg("accent", path)
+                      : theme.fg("toolOutput", "...");
             const offset = args.offset;
             const limit = args.limit;
             if (typeof offset === "number" || typeof limit === "number") {
@@ -221,8 +221,8 @@ function formatToolCallTitle(
                 path == null
                     ? invalidArgLabel()
                     : path
-                        ? theme.fg("accent", path)
-                        : theme.fg("toolOutput", "...");
+                      ? theme.fg("accent", path)
+                      : theme.fg("toolOutput", "...");
             return `${theme.fg("toolTitle", theme.bold(toolName))} ${pathDisplay}`;
         }
         case "grep":
@@ -235,9 +235,9 @@ function formatToolCallTitle(
                 (pattern == null
                     ? invalidArgLabel()
                     : theme.fg(
-                        "accent",
-                        toolName === "grep" ? `/${pattern}/` : pattern,
-                    )) +
+                          "accent",
+                          toolName === "grep" ? `/${pattern}/` : pattern,
+                      )) +
                 theme.fg(
                     "toolOutput",
                     ` in ${path == null ? invalidArgLabel() : path}`,
@@ -436,34 +436,30 @@ function formatToolResultLines(
 }
 
 function renderToolBlock(
-    _bg: ToolBlockBg,
+    bg: ToolBlockBg,
     title: string,
     bodyLines: string[] = [],
 ): string {
-    const blockLines: string[] = [];
-    blockLines.push(""); // top padding
-    blockLines.push("");
-    blockLines.push(`  ${title}`);
-    if (bodyLines.length > 0) {
-        blockLines.push(""); // separator between title and body
-        for (const line of bodyLines) {
-            blockLines.push(`  ${line}`);
-        }
-    }
-    blockLines.push("");
-    blockLines.push(""); // bottom padding
+    const borderColor =
+        bg === "toolErrorBg"
+            ? "error"
+            : bg === "toolSuccessBg"
+              ? "success"
+              : "warning";
 
-    return blockLines.join("\n");
+    const innerLines = [title, ...bodyLines];
+    const wrappedLines = innerLines.map((line) => {
+        const content = line === "" ? " " : line;
+        return `${theme.fg(borderColor, "│")} ${theme.bg(bg, content)} ${theme.fg(borderColor, "│")}`;
+    });
 
-    // BELOW DOES NOT WORK AS EXPECTED
-    // Wrap ALL lines in a single theme.bg() call. The ANSI bg-start code
-    // lands on the first sub-line; wrapTextWithAnsi's AnsiCodeTracker
-    // carries it forward to every subsequent sub-line. Because the bg
-    // reset (\x1b[49m) only appears at the very end, the Markdown
-    // renderer's right-margin and width-padding characters inherit the
-    // active bg — giving us near-full-width coloured blocks without
-    // needing access to the Box component.
-    // return `\n${theme.bg(bg, blockContent)}\n`;
+    return [
+        "",
+        theme.fg(borderColor, "╭─ tool call ─"),
+        ...wrappedLines,
+        theme.fg(borderColor, "╰─────────────"),
+        "",
+    ].join("\n");
 }
 
 export function renderCompletedToolCall(


### PR DESCRIPTION
### Motivation
- Make tool call outputs visually distinct from normal assistant text by rendering them in a boxed layout with a themed background and border coloring so users can more easily notice tool results.

### Description
- Replace the previous plain indented rendering in `src/renderer.ts` with a boxed layout that uses Unicode box characters and per-line `theme.bg` fill to visually separate tool output from chat text.
- Map the incoming `ToolBlockBg` value to a border color (`success`, `error`, `warning`) so success/error/pending results are immediately distinguishable.
- Render the tool title and each result line inside the box and ensure empty lines are preserved as a single-space fill to keep consistent box geometry.
- Leave the `renderCompletedToolCall` API intact while changing its internal block formatting to return the new boxed representation.

### Testing
- Ran `npm run format`, which applied a formatting fix to the modified file and completed successfully.
- Ran `npm run lint` after formatting and observed no lint issues.
- Ran `npm run typecheck` (`tsc --noEmit`) and observed no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec93ac79788321acf95404f2fada7b)