### PR TITLE
fix: use "$CURSOR_API_KEY" format in registerProvider apiKey

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -566,7 +566,7 @@ export default async function (pi: ExtensionAPI) {
 
     pi.registerProvider("cursor", {
         baseUrl: "cli://cursor-agent",
-        apiKey: "CURSOR_API_KEY",
+        apiKey: "$CURSOR_API_KEY",
         api: "cursor-cli" as Api,
         models: toProviderModels(modelDefs),
         streamSimple: createStreamCursorCli(cursorSessionState),


### PR DESCRIPTION
Fixes deprecation warning:

> registerProvider("cursor") apiKey value "CURSOR_API_KEY" is treated as a legacy environment variable reference. This will no longer be detected as an environment variable reference in a future release. Pass "$CURSOR_API_KEY" instead.

Closes #2